### PR TITLE
Fixes #8 - Target correct git revision in Cargo Vendor Pull

### DIFF
--- a/pbs.patch
+++ b/pbs.patch
@@ -62,7 +62,7 @@ diff -Naur -x .git -x target -x tests -x Cargo.lock proxmox-backup.m/Cargo.toml 
 +#proxmox-fuse = "0.1.0"
 +proxmox-fuse = { version = "0.1.0", git = "git://git.proxmox.com/git/proxmox-fuse.git" }
 +#pxar = { version = "0.6.1", features = [ "tokio-io", "futures-io" ] }
-+pxar = { version = "0.6.1", features = [ "tokio-io", "futures-io" ] , git = "git://git.proxmox.com/git/pxar.git"}
++pxar = { version = "0.6.1", features = [ "tokio-io", "futures-io" ] , git = "git://git.proxmox.com/git/pxar.git", rev = "4f2d271a9608b576bf2dad22672a930285b5d7dd"}
  #pxar = { path = "../pxar", features = [ "tokio-io", "futures-io" ] }
  regex = "1.2"
  rustyline = "6"


### PR DESCRIPTION
This fixes the Build issue that new users will be having since pxar has been updated to 0.8.0.

Issue shown below:
`patching file src/tools.rs
    Updating crates.io index
    Updating git repository `git://git.proxmox.com/git/pathpatterns.git`
    Updating git repository `git://git.proxmox.com/git/proxmox-fuse.git`
    Updating git repository `git://git.proxmox.com/git/pxar.git`
error: failed to sync

Caused by:
  failed to load pkg lockfile

Caused by:
  failed to select a version for the requirement `pxar = "^0.6.1"`
  **candidate versions found which didn't match: 0.8.0**
  location searched: Git repository git://git.proxmox.com/git/pxar.git
  required by package `proxmox-backup v1.0.6 (/root/proxmox-backup-client/proxmox-backup)`
error: failed to get `pathpatterns` as a dependency of package `proxmox-backup v1.0.6 (/root/proxmox-backup-client/proxmox-backup)`
`

